### PR TITLE
Fix non-bounded progress on seek change

### DIFF
--- a/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
+++ b/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
@@ -419,16 +419,16 @@ public class SeekArc extends View {
 		if (progress == INVALID_PROGRESS_VALUE) {
 			return;
 		}
+		
+		progress = (progress > mMax) ? mMax : progress;
+		progress = (mProgress < 0) ? 0 : progress;
+		mProgress = progress;
 
 		if (mOnSeekArcChangeListener != null) {
 			mOnSeekArcChangeListener
 					.onProgressChanged(this, progress, fromUser);
 		}
 
-		progress = (progress > mMax) ? mMax : progress;
-		progress = (mProgress < 0) ? 0 : progress;
-
-		mProgress = progress;
 		mProgressSweep = (float) progress / mMax * mSweepAngle;
 
 		updateThumbPosition();

--- a/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
+++ b/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
@@ -421,7 +421,7 @@ public class SeekArc extends View {
 		}
 		
 		progress = (progress > mMax) ? mMax : progress;
-		progress = (mProgress < 0) ? 0 : progress;
+		progress = (progress < 0) ? 0 : progress;
 		mProgress = progress;
 
 		if (mOnSeekArcChangeListener != null) {


### PR DESCRIPTION
Bound checks were done after the value was passed into the progressChanged listener.