### PR TITLE
The ACTION_CANCEL should be removed

### DIFF
--- a/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
+++ b/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
@@ -320,11 +320,6 @@ public class SeekArc extends View {
 			onStopTrackingTouch();
 			setPressed(false);
 			break;
-		case MotionEvent.ACTION_CANCEL:
-			onStopTrackingTouch();
-			setPressed(false);
-
-			break;
 		}
 
 		return true;


### PR DESCRIPTION
The ACTION_CANCEL action should be removed from the onTouch event to provide a better experience of changing values to the user. The ACTION_CANCEL fires way too often.