### PR TITLE
added support for progress markers

### DIFF
--- a/SeekArc_library/res/drawable-mdpi/marker_background.xml
+++ b/SeekArc_library/res/drawable-mdpi/marker_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <stroke
+        android:width="2dp"
+        android:color="@color/default_blue_light" />
+    <solid android:color="@color/default_blue_light" />
+    <size
+        android:width="14dp"
+        android:height="14dp" />
+</shape>

--- a/SeekArc_library/res/drawable-mdpi/marker_empty.xml
+++ b/SeekArc_library/res/drawable-mdpi/marker_empty.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <stroke
+        android:width="2dp"
+        android:color="@color/progress_gray" />
+    <solid android:color="@color/default_blue_light" />
+    <size
+        android:width="14dp"
+        android:height="14dp" />
+</shape>

--- a/SeekArc_library/res/drawable-mdpi/marker_fill.xml
+++ b/SeekArc_library/res/drawable-mdpi/marker_fill.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/marker_background" />
+    <item
+        android:bottom="2px"
+        android:drawable="@drawable/marker_foreground"
+        android:left="2px"
+        android:right="2px"
+        android:top="2px" />
+</layer-list>

--- a/SeekArc_library/res/drawable-mdpi/marker_foreground.xml
+++ b/SeekArc_library/res/drawable-mdpi/marker_foreground.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <stroke
+        android:width="2dp"
+        android:color="@color/progress_gray" />
+    <solid android:color="@color/default_blue_light" />
+    <size
+        android:width="14dp"
+        android:height="14dp" />
+</shape>

--- a/SeekArc_library/res/values/attrs.xml
+++ b/SeekArc_library/res/values/attrs.xml
@@ -39,10 +39,16 @@
         <attr name="touchInside" format="boolean" />
         <attr name="clockwise" format="boolean" />
         <attr name="enabled" format="boolean" />
+        <attr name="markerEmpty" format="reference" />
+        <attr name="markerFill" format="reference" />
+        <attr name="markerTextEmptyColor" format="color" />
+        <attr name="markerTextFillColor" format="color" />
+        <attr name="markerTextSize" format="dimension" />
+        <attr name="markerTextRadius" format="dimension" />
     </declare-styleable>
-    
+
     <declare-styleable name="SeekArcTheme">
-        <attr name="seekArcStyle" format="reference"></attr>        
+        <attr name="seekArcStyle" format="reference"></attr>
     </declare-styleable>
 
 </resources>

--- a/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
+++ b/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
@@ -1,19 +1,19 @@
 /*******************************************************************************
  * The MIT License (MIT)
- * 
+ * <p/>
  * Copyright (c) 2013 Triggertrap Ltd
  * Author Neil Davies
- * 
+ * <p/>
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ * <p/>
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ * <p/>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -28,6 +28,7 @@ import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
@@ -35,20 +36,25 @@ import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 
+import java.util.ArrayList;
+
 /**
- * 
  * SeekArc.java
- * 
+ * <p/>
  * This is a class that functions much like a SeekBar but
  * follows a circle path instead of a straight line.
- * 
+ *
  * @author Neil Davies
- * 
  */
 public class SeekArc extends View {
 
 	private static final String TAG = SeekArc.class.getSimpleName();
 	private static int INVALID_PROGRESS_VALUE = -1;
+	private static final int MARKER_TEXT_SIZE = 18;
+	private static final int TEXT_RADIUS = 40;
+	private static final int MARKER_TOUCH_RADIUS = 48;
+	private static final int CLICK_ACTION_THRESHOLD = 5;
+
 	// The initial rotational offset -90 means we start at 12 o'clock
 	private final int mAngleOffset = -90;
 
@@ -56,62 +62,91 @@ public class SeekArc extends View {
 	 * The Drawable for the seek arc thumbnail
 	 */
 	private Drawable mThumb;
-	
+
+	/**
+	 * The Drawable for the seek arc empty marker
+	 */
+	private Drawable mProgressMarkerEmpty;
+
+	/**
+	 * The Drawable for the seek arc fill marker
+	 */
+	private Drawable mProgressMarkerFill;
+
 	/**
 	 * The Maximum value that this SeekArc can be set to
 	 */
 	private int mMax = 100;
-	
+
 	/**
 	 * The Current value that the SeekArc is set to
 	 */
 	private int mProgress = 0;
-		
+
 	/**
 	 * The width of the progress line for this SeekArc
 	 */
 	private int mProgressWidth = 4;
-	
+
 	/**
-	 * The Width of the background arc for the SeekArc 
+	 * The Width of the background arc for the SeekArc
 	 */
 	private int mArcWidth = 2;
-	
+
 	/**
 	 * The Angle to start drawing this Arc from
 	 */
 	private int mStartAngle = 0;
-	
+
 	/**
 	 * The Angle through which to draw the arc (Max is 360)
 	 */
 	private int mSweepAngle = 360;
-	
+
 	/**
 	 * The rotation of the SeekArc- 0 is twelve o'clock
 	 */
 	private int mRotation = 0;
-	
+
 	/**
 	 * Give the SeekArc rounded edges
 	 */
 	private boolean mRoundedEdges = false;
-	
+
 	/**
 	 * Enable touch inside the SeekArc
 	 */
 	private boolean mTouchInside = true;
-	
+
 	/**
 	 * Will the progress increase clockwise or anti-clockwise
 	 */
 	private boolean mClockwise = true;
 
-
 	/**
 	 * is the control enabled/touchable
- 	 */
+	 */
 	private boolean mEnabled = true;
+
+	/**
+	 * The text color of the empty progress markers.
+	 */
+	private int mMarkerTextColorEmpty;
+
+	/**
+	 * The text color of the filled progress markers.
+	 */
+	private int mMarkerTextColorFill;
+
+	/**
+	 * The text size of the progress markers.
+	 */
+	private float mMarkerTextSize;
+
+	/**
+	 * The text radius of the progress markers. The longer the value, the longer the distance of the text from the marker.
+	 */
+	private int mMarkerTextRadius;
 
 	// Internal variables
 	private int mArcRadius = 0;
@@ -126,6 +161,10 @@ public class SeekArc extends View {
 	private double mTouchAngle;
 	private float mTouchIgnoreRadius;
 	private OnSeekArcChangeListener mOnSeekArcChangeListener;
+	private ArrayList<Marker> mMarkers;
+	private Paint mMarkerTextPaint;
+	private float mClickStartX;
+	private float mClickStartY;
 
 	public interface OnSeekArcChangeListener {
 
@@ -133,36 +172,42 @@ public class SeekArc extends View {
 		 * Notification that the progress level has changed. Clients can use the
 		 * fromUser parameter to distinguish user-initiated changes from those
 		 * that occurred programmatically.
-		 * 
-		 * @param seekArc
-		 *            The SeekArc whose progress has changed
-		 * @param progress
-		 *            The current progress level. This will be in the range
-		 *            0..max where max was set by
-		 *            {@link ProgressArc#setMax(int)}. (The default value for
-		 *            max is 100.)
-		 * @param fromUser
-		 *            True if the progress change was initiated by the user.
+		 *
+		 * @param seekArc  The SeekArc whose progress has changed
+		 * @param progress The current progress level. This will be in the range
+		 *                 0..max where max was set by
+		 *                 {@link SeekArc#setMax(int)}. (The default value for
+		 *                 max is 100.)
+		 * @param fromUser True if the progress change was initiated by the user.
 		 */
 		void onProgressChanged(SeekArc seekArc, int progress, boolean fromUser);
 
 		/**
 		 * Notification that the user has started a touch gesture. Clients may
 		 * want to use this to disable advancing the seekbar.
-		 * 
-		 * @param seekArc
-		 *            The SeekArc in which the touch gesture began
+		 *
+		 * @param seekArc The SeekArc in which the touch gesture began
 		 */
 		void onStartTrackingTouch(SeekArc seekArc);
 
 		/**
 		 * Notification that the user has finished a touch gesture. Clients may
 		 * want to use this to re-enable advancing the seekarc.
-		 * 
-		 * @param seekArc
-		 *            The SeekArc in which the touch gesture began
+		 *
+		 * @param seekArc The SeekArc in which the touch gesture began
 		 */
 		void onStopTrackingTouch(SeekArc seekArc);
+	}
+
+	public interface OnMarkerClickListener {
+
+		/**
+		 * Notification that the user has clicked a marker.
+		 *
+		 * @param value The value of the marker
+		 * @param label The label of the marker
+		 */
+		void onMarkerClicked(int value, String label);
 	}
 
 	public SeekArc(Context context) {
@@ -186,16 +231,25 @@ public class SeekArc extends View {
 		final Resources res = getResources();
 		float density = context.getResources().getDisplayMetrics().density;
 
+		mClickStartX = 0;
+		mClickStartY = 0;
+
 		// Defaults, may need to link this into theme settings
 		int arcColor = res.getColor(R.color.progress_gray);
-		int progressColor = res.getColor(R.color.default_blue_light);
+		int progressColor = res.getColor(android.R.color.holo_blue_light);
 		int thumbHalfheight = 0;
 		int thumbHalfWidth = 0;
 		mThumb = res.getDrawable(R.drawable.seek_arc_control_selector);
+		mProgressMarkerEmpty = res.getDrawable(R.drawable.marker_empty);
+		mProgressMarkerFill = res.getDrawable(R.drawable.marker_fill);
 		// Convert progress width to pixels for current density
 		mProgressWidth = (int) (mProgressWidth * density);
+		mMarkers = new ArrayList<>();
+		mMarkerTextPaint = new Paint();
+		mMarkerTextPaint.setTextSize(MARKER_TEXT_SIZE);
+		mMarkerTextPaint.setAntiAlias(true);
+		mMarkerTextPaint.setTextAlign(Paint.Align.CENTER);
 
-		
 		if (attrs != null) {
 			// Attribute initialization
 			final TypedArray a = context.obtainStyledAttributes(attrs,
@@ -206,11 +260,29 @@ public class SeekArc extends View {
 				mThumb = thumb;
 			}
 
-			
-			
 			thumbHalfheight = (int) mThumb.getIntrinsicHeight() / 2;
 			thumbHalfWidth = (int) mThumb.getIntrinsicWidth() / 2;
 			mThumb.setBounds(-thumbHalfWidth, -thumbHalfheight, thumbHalfWidth,
+					thumbHalfheight);
+
+			thumb = a.getDrawable(R.styleable.SeekArc_markerEmpty);
+			if (thumb != null) {
+				mProgressMarkerEmpty = thumb;
+			}
+
+			thumbHalfheight = (int) mProgressMarkerEmpty.getIntrinsicHeight() / 2;
+			thumbHalfWidth = (int) mProgressMarkerEmpty.getIntrinsicWidth() / 2;
+			mProgressMarkerEmpty.setBounds(-thumbHalfWidth, -thumbHalfheight, thumbHalfWidth,
+					thumbHalfheight);
+
+			thumb = a.getDrawable(R.styleable.SeekArc_markerFill);
+			if (thumb != null) {
+				mProgressMarkerFill = thumb;
+			}
+
+			thumbHalfheight = (int) mProgressMarkerFill.getIntrinsicHeight() / 2;
+			thumbHalfWidth = (int) mProgressMarkerFill.getIntrinsicWidth() / 2;
+			mProgressMarkerFill.setBounds(-thumbHalfWidth, -thumbHalfheight, thumbHalfWidth,
 					thumbHalfheight);
 
 			mMax = a.getInteger(R.styleable.SeekArc_max, mMax);
@@ -229,10 +301,14 @@ public class SeekArc extends View {
 			mClockwise = a.getBoolean(R.styleable.SeekArc_clockwise,
 					mClockwise);
 			mEnabled = a.getBoolean(R.styleable.SeekArc_enabled, mEnabled);
-
 			arcColor = a.getColor(R.styleable.SeekArc_arcColor, arcColor);
 			progressColor = a.getColor(R.styleable.SeekArc_progressColor,
 					progressColor);
+
+			mMarkerTextColorEmpty = a.getColor(R.styleable.SeekArc_markerTextEmptyColor, arcColor);
+			mMarkerTextColorFill = a.getColor(R.styleable.SeekArc_markerTextFillColor, progressColor);
+			mMarkerTextSize = (int) a.getDimension(R.styleable.SeekArc_markerTextSize, MARKER_TEXT_SIZE);
+			mMarkerTextRadius = (int) a.getDimension(R.styleable.SeekArc_markerTextRadius, TEXT_RADIUS);
 
 			a.recycle();
 		}
@@ -242,8 +318,6 @@ public class SeekArc extends View {
 
 		mSweepAngle = (mSweepAngle > 360) ? 360 : mSweepAngle;
 		mSweepAngle = (mSweepAngle < 0) ? 0 : mSweepAngle;
-
-		mProgressSweep = (float) mProgress / mMax * mSweepAngle;
 
 		mStartAngle = (mStartAngle > 360) ? 0 : mStartAngle;
 		mStartAngle = (mStartAngle < 0) ? 0 : mStartAngle;
@@ -268,28 +342,59 @@ public class SeekArc extends View {
 	}
 
 	@Override
-	protected void onDraw(Canvas canvas) {		
-		if(!mClockwise) {
-			canvas.scale(-1, 1, mArcRect.centerX(), mArcRect.centerY() );
+	protected void onDraw(Canvas canvas) {
+		if (!mClockwise) {
+			canvas.scale(-1, 1, mArcRect.centerX(), mArcRect.centerY());
 		}
-		
+
 		// Draw the arcs
 		final int arcStart = mStartAngle + mAngleOffset + mRotation;
 		final int arcSweep = mSweepAngle;
 		canvas.drawArc(mArcRect, arcStart, arcSweep, false, mArcPaint);
-		canvas.drawArc(mArcRect, arcStart, mProgressSweep, false,
-				mProgressPaint);
+		canvas.drawArc(mArcRect, arcStart, mProgressSweep, false, mProgressPaint);
 
-		if(mEnabled) {
+		if (mEnabled) {
 			// Draw the thumb nail
+			canvas.save();
 			canvas.translate(mTranslateX - mThumbXPos, mTranslateY - mThumbYPos);
 			mThumb.draw(canvas);
+			canvas.restore();
+		}
+
+		// Draw the markers
+		if (mMarkers != null && !mMarkers.isEmpty()) {
+			mMarkerTextPaint.setTextSize(mMarkerTextSize);
+			for (Marker marker : mMarkers) {
+				canvas.save();
+				canvas.translate(mTranslateX - marker.posX, mTranslateY - marker.posY);
+				if (mProgress < marker.value) {
+					mProgressMarkerEmpty.draw(canvas);
+					mMarkerTextPaint.setColor(mMarkerTextColorEmpty);
+				} else {
+					mProgressMarkerFill.draw(canvas);
+					mMarkerTextPaint.setColor(mMarkerTextColorFill);
+				}
+				canvas.restore();
+
+				//draw the text of the marker, depending on the angle
+				canvas.save();
+				float textPosX = mTranslateX - marker.textPosX - marker.offsetX;
+				float textPosY = mTranslateY - marker.textPosY - marker.offsetY;
+				canvas.translate(textPosX, textPosY);
+				canvas.drawText(marker.getLabel(), 0, 0, mMarkerTextPaint);
+				canvas.restore();
+			}
 		}
 	}
 
 
 	@Override
 	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+
+		if (mMarkers != null && !mMarkers.isEmpty()) {
+			onMeasureWithMarkers(widthMeasureSpec, heightMeasureSpec);
+			return;
+		}
 
 		final int height = getDefaultSize(getSuggestedMinimumHeight(),
 				heightMeasureSpec);
@@ -302,48 +407,81 @@ public class SeekArc extends View {
 
 		mTranslateX = (int) (width * 0.5f);
 		mTranslateY = (int) (height * 0.5f);
-		
+
 		arcDiameter = min - getPaddingLeft();
 		mArcRadius = arcDiameter / 2;
 		top = height / 2 - (arcDiameter / 2);
 		left = width / 2 - (arcDiameter / 2);
 		mArcRect.set(left, top, left + arcDiameter, top + arcDiameter);
-	
-		int arcStart = (int)mProgressSweep + mStartAngle  + mRotation + 90;
+
+		int arcStart = (int) mProgressSweep + mStartAngle + mRotation + 90;
 		mThumbXPos = (int) (mArcRadius * Math.cos(Math.toRadians(arcStart)));
 		mThumbYPos = (int) (mArcRadius * Math.sin(Math.toRadians(arcStart)));
-		
+
 		setTouchInSide(mTouchInside);
 		super.onMeasure(widthMeasureSpec, heightMeasureSpec);
 	}
 
+	private void onMeasureWithMarkers(int widthMeasureSpec, int heightMeasureSpec) {
+		final int height = getDefaultSize(getSuggestedMinimumHeight(),
+				heightMeasureSpec);
+		final int width = getDefaultSize(getSuggestedMinimumWidth(),
+				widthMeasureSpec);
+		final int min = Math.min(width, height);
+		float top = 0;
+		float left = 0;
+		int arcDiameter = 0;
+
+		mTranslateX = (int) (min * 0.5f);
+		mTranslateY = (int) (min * 0.5f);
+
+		arcDiameter = min - getPaddingLeft() - 2 * mMarkerTextRadius;
+		mArcRadius = arcDiameter / 2;
+		top = min / 2 - (arcDiameter / 2);
+		left = min / 2 - (arcDiameter / 2);
+		mArcRect.set(left, top, left + arcDiameter, top + arcDiameter);
+
+		int arcStart = (int) mProgressSweep + mStartAngle + mRotation + 90;
+		mThumbXPos = (int) (mArcRadius * Math.cos(Math.toRadians(arcStart)));
+		mThumbYPos = (int) (mArcRadius * Math.sin(Math.toRadians(arcStart)));
+
+		updateMarkerPositions();
+
+		setTouchInSide(mTouchInside);
+		setMeasuredDimension(MeasureSpec.makeMeasureSpec(min, MeasureSpec.EXACTLY), MeasureSpec.makeMeasureSpec(min, MeasureSpec.EXACTLY));
+	}
+
 	@Override
 	public boolean onTouchEvent(MotionEvent event) {
-		if (mEnabled) {
-			this.getParent().requestDisallowInterceptTouchEvent(true);
-
-			switch (event.getAction()) {
-				case MotionEvent.ACTION_DOWN:
+		switch (event.getAction()) {
+			case MotionEvent.ACTION_DOWN:
+				startClick(event.getX(), event.getY());
+				if (mEnabled) {
 					onStartTrackingTouch();
 					updateOnTouch(event);
-					break;
-				case MotionEvent.ACTION_MOVE:
+				}
+				break;
+			case MotionEvent.ACTION_MOVE:
+				if (mEnabled) {
 					updateOnTouch(event);
-					break;
-				case MotionEvent.ACTION_UP:
+				}
+				break;
+			case MotionEvent.ACTION_UP:
+				endClick(event.getX(), event.getY());
+				if (mEnabled) {
 					onStopTrackingTouch();
 					setPressed(false);
-					this.getParent().requestDisallowInterceptTouchEvent(false);
-					break;
-				case MotionEvent.ACTION_CANCEL:
+				}
+				break;
+			case MotionEvent.ACTION_CANCEL:
+				if (mEnabled) {
 					onStopTrackingTouch();
 					setPressed(false);
-					this.getParent().requestDisallowInterceptTouchEvent(false);
-					break;
-			}
-			return true;
+				}
+				break;
 		}
-		return false;
+
+		return true;
 	}
 
 	@Override
@@ -354,6 +492,35 @@ public class SeekArc extends View {
 			mThumb.setState(state);
 		}
 		invalidate();
+	}
+
+	private void startClick(float posX, float posY) {
+		mClickStartX = posX;
+		mClickStartY = posY;
+		setPressed(true);
+	}
+
+	private void endClick(float posX, float posY) {
+		setPressed(false);
+		if (mMarkers == null || !isAClick(mClickStartX, posX, mClickStartY, posY)) {
+			return;
+		}
+		float minimumDist = Float.MAX_VALUE;
+		Marker markerToClick = null;
+		for (Marker marker : mMarkers) {
+			if (marker.onMarkerClickListener == null) {
+				continue;
+			}
+			float dist = getEuclideanDistance(mTranslateX - marker.posX, mTranslateY - marker.posY, posX, posY);
+			if (dist > MARKER_TOUCH_RADIUS || dist > minimumDist) {
+				continue;
+			}
+			minimumDist = dist;
+			markerToClick = marker;
+		}
+		if (markerToClick != null) {
+			markerToClick.onMarkerClickListener.onMarkerClicked(markerToClick.value, markerToClick.getLabel());
+		}
 	}
 
 	private void onStartTrackingTouch() {
@@ -395,7 +562,7 @@ public class SeekArc extends View {
 		float x = xPos - mTranslateX;
 		float y = yPos - mTranslateY;
 		//invert the x-coord if we are rotating anti-clockwise
-		x= (mClockwise) ? x:-x;
+		x = (mClockwise) ? x : -x;
 		// convert to arc Angle
 		double angle = Math.toDegrees(Math.atan2(y, x) + (Math.PI / 2)
 				- Math.toRadians(mRotation));
@@ -428,23 +595,42 @@ public class SeekArc extends View {
 		int thumbAngle = (int) (mStartAngle + mProgressSweep + mRotation + 90);
 		mThumbXPos = (int) (mArcRadius * Math.cos(Math.toRadians(thumbAngle)));
 		mThumbYPos = (int) (mArcRadius * Math.sin(Math.toRadians(thumbAngle)));
+		updateMarkerPositions();
 	}
-	
+
+	private void updateMarkerPositions() {
+		if (mMarkers == null) {
+			mMarkers = new ArrayList<>();
+			return;
+		}
+		if (mMarkers.isEmpty()) {
+			return;
+		}
+		int angle = 0;
+		for (Marker marker : mMarkers) {
+			angle = (int) (mStartAngle + marker.progressSweep + mRotation + 90);
+			marker.posX = (int) (mArcRadius * Math.cos(Math.toRadians(angle)));
+			marker.posY = (int) (mArcRadius * Math.sin(Math.toRadians(angle)));
+			marker.textPosX = (int) ((mArcRadius + TEXT_RADIUS) * Math.cos(Math.toRadians(angle)));
+			marker.textPosY = (int) ((mArcRadius + TEXT_RADIUS) * Math.sin(Math.toRadians(angle)));
+		}
+	}
+
 	private void updateProgress(int progress, boolean fromUser) {
 
 		if (progress == INVALID_PROGRESS_VALUE) {
 			return;
 		}
 
-		progress = (progress > mMax) ? mMax : progress;
-		progress = (progress < 0) ? 0 : progress;
-		mProgress = progress;
-
 		if (mOnSeekArcChangeListener != null) {
 			mOnSeekArcChangeListener
 					.onProgressChanged(this, progress, fromUser);
 		}
 
+		progress = (progress > mMax) ? mMax : progress;
+		progress = (mProgress < 0) ? 0 : progress;
+
+		mProgress = progress;
 		mProgressSweep = (float) progress / mMax * mSweepAngle;
 
 		updateThumbPosition();
@@ -456,11 +642,9 @@ public class SeekArc extends View {
 	 * Sets a listener to receive notifications of changes to the SeekArc's
 	 * progress level. Also provides notifications of when the user starts and
 	 * stops a touch gesture within the SeekArc.
-	 * 
-	 * @param l
-	 *            The seek bar notification listener
-	 * 
-	 * @see SeekArc.OnSeekBarChangeListener
+	 *
+	 * @param l The seek bar notification listener
+	 * @see SeekArc.OnSeekArcChangeListener
 	 */
 	public void setOnSeekArcChangeListener(OnSeekArcChangeListener l) {
 		mOnSeekArcChangeListener = l;
@@ -468,10 +652,6 @@ public class SeekArc extends View {
 
 	public void setProgress(int progress) {
 		updateProgress(progress, false);
-	}
-
-	public int getProgress() {
-		return mProgress;
 	}
 
 	public int getProgressWidth() {
@@ -482,7 +662,7 @@ public class SeekArc extends View {
 		this.mProgressWidth = mProgressWidth;
 		mProgressPaint.setStrokeWidth(mProgressWidth);
 	}
-	
+
 	public int getArcWidth() {
 		return mArcWidth;
 	}
@@ -491,6 +671,7 @@ public class SeekArc extends View {
 		this.mArcWidth = mArcWidth;
 		mArcPaint.setStrokeWidth(mArcWidth);
 	}
+
 	public int getArcRotation() {
 		return mRotation;
 	}
@@ -517,7 +698,7 @@ public class SeekArc extends View {
 		this.mSweepAngle = mSweepAngle;
 		updateThumbPosition();
 	}
-	
+
 	public void setRoundedEdges(boolean isEnabled) {
 		mRoundedEdges = isEnabled;
 		if (mRoundedEdges) {
@@ -528,7 +709,7 @@ public class SeekArc extends View {
 			mProgressPaint.setStrokeCap(Paint.Cap.SQUARE);
 		}
 	}
-	
+
 	public void setTouchInSide(boolean isEnabled) {
 		int thumbHalfheight = (int) mThumb.getIntrinsicHeight() / 2;
 		int thumbHalfWidth = (int) mThumb.getIntrinsicWidth() / 2;
@@ -541,7 +722,7 @@ public class SeekArc extends View {
 					- Math.min(thumbHalfWidth, thumbHalfheight);
 		}
 	}
-	
+
 	public void setClockwise(boolean isClockwise) {
 		mClockwise = isClockwise;
 	}
@@ -582,5 +763,126 @@ public class SeekArc extends View {
 
 	public void setMax(int mMax) {
 		this.mMax = mMax;
+	}
+
+	public int getMarkerTextColorEmpty() {
+		return mMarkerTextColorEmpty;
+	}
+
+	public void setMarkerTextColorEmpty(int color) {
+		mMarkerTextColorEmpty = color;
+		invalidate();
+	}
+
+	public int getMarkerTextColorFill() {
+		return mMarkerTextColorFill;
+	}
+
+	public void setMarkerTextColorFill(int color) {
+		mMarkerTextColorFill = color;
+		invalidate();
+	}
+
+	public void setTextSize(float size) {
+		mMarkerTextSize = size;
+		invalidate();
+	}
+
+	public float getTextSize() {
+		return mMarkerTextSize;
+	}
+
+	public void setTextRadius(int textRadius) {
+		if (textRadius > 0) {
+			mMarkerTextRadius = textRadius;
+			invalidate();
+		}
+	}
+
+	public int getTextRadius() {
+		return mMarkerTextRadius;
+	}
+
+	/**
+	 * Adds a marker on the SeekArc. If parameter label is provided (not null), then it will be shown as label on the marker,
+	 * else the value will be shown as label.
+	 *
+	 * @param label                 The label of the marker.
+	 * @param value                 The progress value of the marker
+	 * @param textOffsetX           The X offset of the label
+	 * @param textOffsetY           The Y offset of the label
+	 * @param onMarkerClickListener The listener that corresponds to the click events of the marker. It can be null.
+	 * @return True if the marker was added successfully, false otherwise.
+	 */
+	public boolean addMarker(String label, int value, int textOffsetX, int textOffsetY, OnMarkerClickListener onMarkerClickListener) {
+		if (value > mMax || value < 0) {
+			return false;
+		}
+		Marker marker = new Marker();
+		String lb = label;
+		if (label != null && label.length() > 6) {
+			lb = label.substring(0, 6);
+		}
+		marker.label = lb;
+		marker.value = value;
+		marker.offsetX = textOffsetX;
+		marker.offsetY = textOffsetY;
+		marker.progressSweep = (float) value / mMax * mSweepAngle;
+		marker.onMarkerClickListener = onMarkerClickListener;
+		if (mMarkers == null) {
+			mMarkers = new ArrayList<>();
+		}
+		mMarkers.add(marker);
+		requestLayout();
+		postInvalidate();
+		return true;
+	}
+
+	private float getEuclideanDistance(float pos1X, float pos1Y, float pos2X, float pos2Y) {
+		float x = pos2X - pos1X;
+		float y = pos2Y - pos1Y;
+		return (float) Math.sqrt(((x * x) + (y * y)));
+	}
+
+	private boolean isAClick(float startX, float endX, float startY, float endY) {
+		float difference = getEuclideanDistance(startX, startY, endX, endY);
+		return difference <= CLICK_ACTION_THRESHOLD;
+	}
+
+	private class Marker {
+		int posX;
+		int posY;
+		int textPosX;
+		int textPosY;
+		int offsetX;
+		int offsetY;
+		String label;
+		int value;
+		float progressSweep;
+		Rect textBounds;
+		OnMarkerClickListener onMarkerClickListener;
+
+		Marker() {
+			posX = 0;
+			posY = 0;
+			textPosX = 0;
+			textPosY = 0;
+			offsetX = 0;
+			offsetY = 0;
+			value = 0;
+			label = null;
+			progressSweep = 0;
+			textBounds = new Rect();
+			onMarkerClickListener = null;
+		}
+
+		String getLabel() {
+			String result = String.valueOf(value);
+			if (label != null) {
+				result = label;
+			}
+			mMarkerTextPaint.getTextBounds(result, 0, result.length(), textBounds);
+			return result;
+		}
 	}
 }

--- a/SeekArc_sample/AndroidManifest.xml
+++ b/SeekArc_sample/AndroidManifest.xml
@@ -63,6 +63,10 @@
             android:name="com.triggertrap.sample.CustomActivity"
             android:label="@string/title_activity_custom" >
         </activity>
+        <activity
+            android:name="com.triggertrap.sample.MarkerActivity"
+            android:label="@string/title_activity_markers" >
+        </activity>
     </application>
 
 </manifest>

--- a/SeekArc_sample/res/layout/activity_marker.xml
+++ b/SeekArc_sample/res/layout/activity_marker.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:seekarc="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.triggertrap.seekarc.SeekArc
+        android:id="@+id/markerSeekArc"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:padding="85dp"
+        seekarc:arcWidth="3dp"
+        seekarc:markerTextEmptyColor="@android:color/tertiary_text_light"
+        seekarc:markerTextFillColor="@android:color/black"
+        seekarc:markerTextRadius="42dp"
+        seekarc:markerTextSize="14sp"
+        seekarc:max="100"
+        seekarc:rotation="180"
+        seekarc:startAngle="30"
+        seekarc:sweepAngle="300"
+        seekarc:thumb="@android:color/transparent"
+        seekarc:touchInside="true" />
+
+</LinearLayout>

--- a/SeekArc_sample/res/values/strings.xml
+++ b/SeekArc_sample/res/values/strings.xml
@@ -31,11 +31,13 @@
         <item>@string/title_activity_custom</item>
         <item>@string/title_activity_scrollview</item>
         <item>@string/title_activity_disabled</item>
+        <item>@string/title_activity_markers</item>
     </string-array>
 
     <string name="title_activity_simple">SeekArc (default)</string>
     <string name="title_activity_custom">Custom style</string>
     <string name="title_activity_scrollview">In scrollview</string>
     <string name="title_activity_disabled">Disabled (read only)</string>
+    <string name="title_activity_markers">With Markers</string>
 
 </resources>

--- a/SeekArc_sample/src/com/triggertrap/sample/MainActivity.java
+++ b/SeekArc_sample/src/com/triggertrap/sample/MainActivity.java
@@ -1,19 +1,19 @@
 /*******************************************************************************
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2013 Triggertrap Ltd
  * Author Neil Davies
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -32,20 +32,20 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
 /**
- * 
+ *
  * MainActivity.java
  * @author Neil Davies
- * 
+ *
  */
 public class MainActivity extends ListActivity {
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		
+
 		String [] items = getResources().getStringArray(R.array.items);
 		setListAdapter(new ArrayAdapter<String>(this,
-                android.R.layout.simple_list_item_1, items));
+				android.R.layout.simple_list_item_1, items));
 	}
 
 	@Override
@@ -66,6 +66,10 @@ public class MainActivity extends ListActivity {
 				break;
 			case 3:
 				intent = new Intent(this, DisabledActivity.class);
+				startActivity(intent);
+				break;
+			case 4:
+				intent = new Intent(this, MarkerActivity.class);
 				startActivity(intent);
 				break;
 		}

--- a/SeekArc_sample/src/com/triggertrap/sample/MarkerActivity.java
+++ b/SeekArc_sample/src/com/triggertrap/sample/MarkerActivity.java
@@ -1,0 +1,32 @@
+package com.triggertrap.sample;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import com.triggertrap.seekarc.SeekArc;
+
+/**
+ * Created by aggelos on 30/12/2015.
+ */
+public class MarkerActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_marker);
+
+        SeekArc markerSeekArc = (SeekArc) findViewById(R.id.markerSeekArc);
+        markerSeekArc.setMax(100);
+        markerSeekArc.addMarker(null, 20, 0, 0, onMarkerClickListener);
+        markerSeekArc.addMarker("label", 70, 0, 0, onMarkerClickListener);
+        markerSeekArc.addMarker(null, 40, 0, 0, onMarkerClickListener);
+    }
+
+    SeekArc.OnMarkerClickListener onMarkerClickListener = new SeekArc.OnMarkerClickListener() {
+        @Override
+        public void onMarkerClicked(int value, String label) {
+            Toast.makeText(MarkerActivity.this, label + " clicked", Toast.LENGTH_SHORT).show();
+        }
+    };
+}


### PR DESCRIPTION
Hello! I added markers functionality to your project (as requested in " Creating a marker at discrete progress #25"). Markers can have two states, empty if the progress of the SeekArc has not yet reached the marker value or fill otherwise. Also, markers can have a label which is drawn outside of the SeecArc circle. Finally, markers can have (optionally) a click listener.

New xml attributes introduced (with getters/setters in SeekArc class):
- markerEmpty (type: drawable) : The drawable of the empty state marker.
- markerFill (type: drawable) : The drawable of the fill state marker.
- markerTextEmptyColor (type: color) : The label color of the empty state marker.
- markerTextFillColor (type: color) : The label color of the fill state marker.
- markerTextSize (type: dimension) : The label text size of the marker.
- markerTextRadius (type: dimension) : The radius of the circle from the label text center to the point adjusted to the SeekArc circle. The longer the value, the longer the distance from the marker.

To add a marker you need to call method addMarker(String label, int value, int textOffsetX, int textOffsetY, OnMarkerClickListener onMarkerClickListener)

where:
- label : The label of the marker. If not provided (null), the parameter value will be shown as label
- value : The progress value of the marker
- textOffsetX : The X offset of the label
- textOffsetY : The Y offset of the label
- onMarkerClickListener :The listener that corresponds to the click events of the marker. It can be null.

I have updated your example with a use case. If you find it usefull please merge, or else just ignore. Thanks!
