### PR TITLE
call invalidate() in setEnabled()

### DIFF
--- a/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
+++ b/SeekArc_library/src/com/triggertrap/seekarc/SeekArc.java
@@ -556,6 +556,7 @@ public class SeekArc extends View {
 
 	public void setEnabled(boolean enabled) {
 		this.mEnabled = enabled;
+		invalidate();
 	}
 
 	public int getProgressColor() {


### PR DESCRIPTION
invalidate() should be called in setEnabled() method to force the seekarc to redraw
